### PR TITLE
some keys do the wrong character, so fix that.

### DIFF
--- a/keyboard.cpp
+++ b/keyboard.cpp
@@ -65,7 +65,7 @@ uint32_t KeyboardDriver::HandleInterrupt(uint32_t esp)
             case 0x2B: printf("#"); break;
 
 
-            case 0x2C: printf("y"); break;
+            case 0x2C: printf("z"); break;
             case 0x2D: printf("x"); break;
             case 0x2E: printf("c"); break;
             case 0x2F: printf("v"); break;
@@ -74,7 +74,7 @@ uint32_t KeyboardDriver::HandleInterrupt(uint32_t esp)
             case 0x32: printf("m"); break;
             case 0x33: printf(","); break;
             case 0x34: printf("."); break;
-            case 0x35: printf("-"); break;
+            case 0x35: printf("/"); break;
 
             case 0x1C: printf("\n"); break;
             case 0x39: printf(" "); break;


### PR DESCRIPTION
z was y, and / was -